### PR TITLE
Changes in install_requires for oauthlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     include_package_data=True,
     platforms="any",
     install_requires=[
-        "requests>=2.21.0", "oauthlib==2.1.0", "requests-oauthlib==1.0.0",
+        "requests>=2.21.0", "oauthlib>=2.1.0", "requests-oauthlib==1.0.0",
     ],
     test_suite='nose.collector',
     tests_require=["nose==1.3.7"],


### PR DESCRIPTION
now requires any `version >= 2.1.0` instead of `version == 2.1.0`